### PR TITLE
IE/Edge - add a 'If-None-Match' header on requests from captured form elements to prevent a caching issues

### DIFF
--- a/src/screen/RequestScreen.js
+++ b/src/screen/RequestScreen.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import { core } from 'metal';
+import { core, string } from 'metal';
 import Ajax from 'metal-ajax';
 import MultiMap from 'metal-multimap';
 import CancellablePromise from 'metal-promise';
@@ -190,13 +190,16 @@ class RequestScreen extends Screen {
 		var body = null;
 		var httpMethod = this.httpMethod;
 
+		var headers = new MultiMap();
+		Object.keys(this.httpHeaders).forEach(header => headers.add(header, this.httpHeaders[header]));
+
 		if (globals.capturedFormElement) {
 			body = new FormData(globals.capturedFormElement);
 			httpMethod = RequestScreen.POST;
+			if (UA.isIeOrEdge) {
+				headers.add('If-None-Match', string.getRandomString());
+			}
 		}
-
-		var headers = new MultiMap();
-		Object.keys(this.httpHeaders).forEach(header => headers.add(header, this.httpHeaders[header]));
 
 		var requestPath = this.formatLoadPath(path);
 		return Ajax

--- a/test/screen/RequestScreen.js
+++ b/test/screen/RequestScreen.js
@@ -218,4 +218,16 @@ describe('RequestScreen', function() {
 		this.requests[0].respond(200);
 	});
 
+	it('should not cache redirected requests on edge browsers', (done) => {
+		UA.testUserAgent('Edge'); // Simulates edge user agent
+		globals.capturedFormElement = globals.document.createElement('form');
+		var url = '/url';
+		var screen = new RequestScreen();
+		screen.load(url).then(() => {
+			assert.ok(screen.getRequest().requestHeaders['If-None-Match']);
+			done();
+		});
+		this.requests[0].respond(200);
+	});
+
 });


### PR DESCRIPTION
Hey Bruno,

Attached is a potential fix for https://github.com/liferay/senna.js/issues/126 and https://issues.liferay.com/browse/LPS-63690.

All these changes do is add the header `If-None-Match`, with a random string as the value, to the post requests of captured form elements.  This is so that if the request is redirected, the header will then be on that request too, and IE will make sure the response is fresh.  I tried many ways to get IE to stop caching the redirect but this was the only way that actually worked.  It seems IE/Edge ignores Cache-Control/Expires headers on XmlHttpRequests.

Please let me know what you think.

Thanks!
