### PR TITLE
Wait until pending navigate is complete before removing screen

### DIFF
--- a/src/app/App.js
+++ b/src/app/App.js
@@ -499,7 +499,14 @@ class App extends EventEmitter {
 	handleNavigateError_(path, nextScreen, err) {
 		console.log('Navigation error for [' + nextScreen + '] (' + err + ')');
 		if (!utils.isCurrentBrowserPath(path)) {
-			this.removeScreen(path);
+			 if (this.pendingNavigate) {
+			 	this.pendingNavigate.thenAlways(function() {
+					this.removeScreen(path);
+		 		}, this);
+		 	}
+		 	else {
+		 		this.removeScreen(path);
+		 	}
 		}
 	}
 

--- a/test/app/App.js
+++ b/test/app/App.js
@@ -1261,6 +1261,36 @@ describe('App', function() {
 			.cancel();
 	});
 
+	it('should wait for pendingNavigate before removing screen on double back navigation', (done) => {
+		class CacheScreen extends Screen {
+			constructor() {
+				super();
+				this.cacheable = true;
+			}
+		}
+
+		var app = new App();
+		this.app = app;
+		app.addRoutes(new Route('/path1', CacheScreen));
+		app.addRoutes(new Route('/path2', CacheScreen));
+		app.addRoutes(new Route('/path3', CacheScreen));
+
+		app.navigate('/path1')
+			.then(() => app.navigate('/path2'))
+			.then(() => app.navigate('/path3'))
+			.then(() => {
+				app.on('endNavigate', function() {
+					assert.ok(app.screens['/path2']);
+					app.pendingNavigate.then(function() {
+						assert.ok(!app.screens['/path2']);
+						done();
+					});
+				});
+				globals.window.history.back();
+				globals.window.history.back();
+			});
+	});
+
 });
 
 var canScrollIFrame_ = false;


### PR DESCRIPTION
Hey Bruno,

Attached is a potential fix for https://github.com/liferay/senna.js/issues/136.

These changes should make senna wait until the current pendingNavigate is complete before removing the screen.  

I'll be on vacation/camping next week so I may not be available.  But please still let me know if there are any issues.

Thanks!
